### PR TITLE
Removes redundant upload success alert

### DIFF
--- a/global_neighbor/static/js/library/library_upload_modal.js
+++ b/global_neighbor/static/js/library/library_upload_modal.js
@@ -100,7 +100,6 @@ document.addEventListener('DOMContentLoaded', () => {
       });
 
       if (response.ok) {
-        alert("Upload successful!");
         closeUploadModal();
         location.reload();
       } else {

--- a/global_neighbor/templates/library/library.html
+++ b/global_neighbor/templates/library/library.html
@@ -56,19 +56,22 @@
       <div class="doc-category">{{ doc.category.name }}</div>
     {% endif %}
 
-    {% if doc.tags.all %}
-      <div class="doc-tags">
-        {% for tag in doc.tags.all %}
-          <span class="tag">{{ tag.name }}</span>
-        {% endfor %}
-      </div>
-    {% endif %}
+    {# REMOVED visible tag chips from the card #}
+    {# <div class="doc-tags"> ... </div> #}
 
     <div class="doc-actions">
-      <a href="{% url 'download_document' doc.id %}" class="action-btn" title="Download">
-        <i class="fa fa-download"></i>
-      </a>
-      {% if request.user == doc.uploaded_by or request.user.is_superuser %}
+      {# Download: neighbor+ or superuser #}
+      {% if request.user.is_authenticated and request.user.is_superuser or request.user.is_neighbor or request.user.is_creator or request.user.is_moderator %}
+        <a href="{% url 'download_document' doc.id %}" class="action-btn" title="Download">
+          <i class="fa fa-download"></i>
+        </a>
+      {% else %}
+        {# Optional: show a login affordance if you like #}
+        {# <a href="{% url 'login' %}" class="action-btn" title="Log in to download"><i class="fa fa-sign-in-alt"></i></a> #}
+      {% endif %}
+
+      {# Edit/Delete: uploader or superuser #}
+      {% if request.user.is_authenticated and request.user == doc.uploaded_by or request.user.is_superuser %}
         <a href="{% url 'edit_document' doc.id %}" class="action-btn" title="Edit metadata">
           <i class="fa fa-pen"></i>
         </a>

--- a/global_neighbor/templates/library/library.html
+++ b/global_neighbor/templates/library/library.html
@@ -38,14 +38,14 @@
 <div id="document-list-container" class="thumbnail-view" style="margin-top: 1rem;">
   {% for doc in documents %}
   <div class="document-card"
-      data-title="{{ doc.title|default_if_none:"Untitled Document" }}"
-      data-author="{{ doc.author|default_if_none:"" }}"
-      data-category="{{ doc.category.name|default_if_none:"" }}"
+      data-title="{{ doc.title|default_if_none:'Untitled Document' }}"
+      data-author="{{ doc.author|default_if_none:'' }}"
+      data-category="{{ doc.category.name|default_if_none:'' }}"
       data-tags="{% for tag in doc.tags.all %}{{ tag.name }}{% if not forloop.last %} {% endif %}{% endfor %}">
 
     <div class="card-header">
       <a href="{% url 'document_detail' doc.id %}" class="document-title">
-        <strong>{{ doc.title|default:"Untitled Document" }}</strong>
+        <strong>{{ doc.title|default:'Untitled Document' }}</strong>
       </a>
       {% if doc.author %}
         <div class="doc-author">by {{ doc.author }}</div>


### PR DESCRIPTION
Removes the redundant JavaScript alert that appeared upon successful document upload.

The success of the upload is already indicated by the page reload, making the alert unnecessary and disruptive to the user experience.